### PR TITLE
feat: add time generator

### DIFF
--- a/rospbt/ros1/generators/builtin_msg_field_types.py
+++ b/rospbt/ros1/generators/builtin_msg_field_types.py
@@ -15,8 +15,12 @@ message field types which are usable in both, ROS1 and ROS2
 
 """
 
+from collections import namedtuple
 import datetime
-from hypothesis.strategies import booleans, datetimes, floats, integers
+from hypothesis.strategies import booleans, composite, datetimes, floats, \
+    integers
+
+_Time = namedtuple('Time', 'secs nsecs')
 
 INT8_MIN_VALUE = -1 * 2 ^ 7
 """int: Minimal Int8 value (-1 * 2^7)."""
@@ -321,3 +325,20 @@ def date(min_value=DATE_MIN_VALUE, max_value=DATE_MAX_VALUE):
 
     """
     return datetimes(min_value, max_value)
+
+
+@composite
+def time(draw, time=float32()):
+    """
+    Generate value for ROS builtin message "time".
+
+    Parameters
+    ----------
+    time : hypothesis.strategies.floats()
+        Strategy to generate time value.
+    """
+    float_secs = draw(time)
+    secs = int(float_secs)
+    nsecs = int((float_secs - secs) * 1000000000)
+
+    return _Time(secs, nsecs)

--- a/tests/test_builtin_msg_field_types.py
+++ b/tests/test_builtin_msg_field_types.py
@@ -3,7 +3,6 @@
 Unit tests for the generators of the built-in message field datatypes.
 """
 
-import datetime
 from hypothesis import given
 from rospbt.ros1.generators import builtin_msg_field_types
 
@@ -82,3 +81,17 @@ def test_date_generates_in_range_value_per_default(generated_value):
     """Verify default min. generated value for Date."""
     assert generated_value >= builtin_msg_field_types.DATE_MIN_VALUE
     assert generated_value <= builtin_msg_field_types.DATE_MAX_VALUE
+
+@given(builtin_msg_field_types.time(
+    builtin_msg_field_types.float32(min_value=0.0,
+                                    max_value=builtin_msg_field_types.UINT32_MAX_VALUE
+                                    ))
+)
+def test_time_generates_in_range_value_per_default(generated_value):
+    """Verify default min. generated value for Time."""
+    secs = generated_value.secs
+    nsecs = generated_value.nsecs
+    assert secs  <= builtin_msg_field_types.UINT32_MAX_VALUE
+    assert nsecs <= builtin_msg_field_types.UINT32_MAX_VALUE
+    assert secs  >= builtin_msg_field_types.UINT32_MIN_VALUE
+    assert nsecs >= builtin_msg_field_types.UINT32_MIN_VALUE


### PR DESCRIPTION
Given the definition here http://wiki.ros.org/msg#Fields and reading the source code here https://docs.ros.org/diamondback/api/rospy/html/rospy.rostime-pysrc.html#Time.now .

Time is in python, 2 unsigned 32 bits integers. In C++, they are signed though.

It looks a bit too simple so please tell me if you had anything else in mind

resolves #13